### PR TITLE
make rules a little more ideomatic

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+ij_continuation_indent_size = 8
+tab_width = 4
+trim_trailing_whitespace = true
+
+[{*.kt,*.kts}]
+ij_kotlin_allow_trailing_comma = false
+ij_kotlin_allow_trailing_comma_on_call_site = false
+ij_kotlin_name_count_to_use_star_import_for_members = 20
+ij_kotlin_name_count_to_use_star_import = 20
+ij_kotlin_continuation_indent_size = 4
+ktlint_code_style=intellij_idea
+
+[*.java]
+ij_java_names_count_to_use_import_on_demand = 20
+ij_java_class_count_to_use_import_on_demand = 20


### PR DESCRIPTION
make rules a little more ideomatic and reduce redundant message strings by leveraging automatic message generation

notice: `.as("Methods annotated with @TaskAction should not " + actionDescription)` is no longer needed