### PR TITLE
Add Gradle plugin development ArchUnit rules for lazy task registration and Provider API usage with field-specific recommendations

### DIFF
--- a/archrules-gradle-plugin-development/src/archRules/java/com/netflix/nebula/archrules/gradleplugins/GradlePluginLazyTaskRegistrationRule.java
+++ b/archrules-gradle-plugin-development/src/archRules/java/com/netflix/nebula/archrules/gradleplugins/GradlePluginLazyTaskRegistrationRule.java
@@ -1,0 +1,93 @@
+package com.netflix.nebula.archrules.gradleplugins;
+
+import com.netflix.nebula.archrules.core.ArchRulesService;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.Priority;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Rules for Gradle plugin classes to ensure they use lazy task registration.
+ * <p>
+ * Lazy task registration (using {@code tasks.register()}) improves configuration time
+ * by avoiding eager task creation. This is critical for build performance, especially
+ * in large multi-module projects.
+ */
+@NullMarked
+public class GradlePluginLazyTaskRegistrationRule implements ArchRulesService {
+
+    private static final Set<String> EAGER_TASK_CREATION_METHODS = new HashSet<>(Arrays.asList(
+            "task",
+            "create"
+    ));
+
+    /**
+     * Prevents Plugin classes from using eager task creation methods.
+     * <p>
+     * Eager task creation (using {@code task()} or {@code tasks.create()}) creates
+     * all tasks during configuration phase, even if they won't be executed.
+     * Use {@code tasks.register()} instead for lazy task creation.
+     */
+    public static final ArchRule pluginsShouldUseLazyTaskRegistration = ArchRuleDefinition.priority(Priority.MEDIUM)
+            .classes()
+            .that().implement("org.gradle.api.Plugin")
+            .should(useLazyTaskRegistration())
+            .allowEmptyShould(true)
+            .because(
+                    "Plugins should use tasks.register() instead of task() or tasks.create() for lazy task registration. " +
+                    "Eager task creation runs during configuration phase on EVERY build, significantly impacting performance. " +
+                    "Lazy registration with tasks.register() only creates tasks when needed. " +
+                    "See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html"
+            );
+
+    private static ArchCondition<JavaClass> useLazyTaskRegistration() {
+        return new ArchCondition<JavaClass>("use lazy task registration (tasks.register())") {
+            @Override
+            public void check(JavaClass pluginClass, ConditionEvents events) {
+                pluginClass.getMethodCallsFromSelf().forEach(call -> {
+                    if (isEagerTaskCreation(call)) {
+                        String message = String.format(
+                                "Plugin %s uses eager task creation with %s.%s() at %s. " +
+                                "Use tasks.register() instead for lazy task registration.",
+                                pluginClass.getSimpleName(),
+                                call.getTargetOwner().getSimpleName(),
+                                call.getName(),
+                                call.getDescription()
+                        );
+                        events.add(SimpleConditionEvent.violated(call, message));
+                    }
+                });
+            }
+
+            private boolean isEagerTaskCreation(JavaMethodCall call) {
+                String methodName = call.getName();
+
+                if (!EAGER_TASK_CREATION_METHODS.contains(methodName)) {
+                    return false;
+                }
+
+                JavaClass targetOwner = call.getTargetOwner();
+                return targetOwner.isAssignableTo("org.gradle.api.Project") ||
+                       targetOwner.isAssignableTo("org.gradle.api.tasks.TaskContainer");
+            }
+        };
+    }
+
+    @Override
+    public Map<String, ArchRule> getRules() {
+        Map<String, ArchRule> rules = new HashMap<>();
+        rules.put("gradle-plugin-lazy-task-registration", pluginsShouldUseLazyTaskRegistration);
+        return rules;
+    }
+}

--- a/archrules-gradle-plugin-development/src/archRules/java/com/netflix/nebula/archrules/gradleplugins/GradleTaskProviderApiRule.java
+++ b/archrules-gradle-plugin-development/src/archRules/java/com/netflix/nebula/archrules/gradleplugins/GradleTaskProviderApiRule.java
@@ -1,0 +1,246 @@
+package com.netflix.nebula.archrules.gradleplugins;
+
+import com.netflix.nebula.archrules.core.ArchRulesService;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.Priority;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Rules for Gradle task classes to ensure they use the Provider API for lazy configuration.
+ * <p>
+ * The Provider API ({@code Property<T>}, {@code Provider<T>}, {@code ConfigurableFileCollection})
+ * enables lazy configuration and configuration avoidance, which are critical for build performance.
+ */
+@NullMarked
+public class GradleTaskProviderApiRule  implements ArchRulesService {
+
+    private static final String JAVA_IO_FILE = "java.io.File";
+    private static final String JAVA_LANG_STRING = "java.lang.String";
+    private static final String JAVA_LANG_INTEGER = "java.lang.Integer";
+    private static final String JAVA_LANG_LONG = "java.lang.Long";
+    private static final String JAVA_LANG_BOOLEAN = "java.lang.Boolean";
+    private static final String JAVA_LANG_DOUBLE = "java.lang.Double";
+    private static final String JAVA_LANG_FLOAT = "java.lang.Float";
+    private static final String JAVA_UTIL_LIST = "java.util.List";
+    private static final String JAVA_UTIL_SET = "java.util.Set";
+    private static final String JAVA_UTIL_MAP = "java.util.Map";
+
+    private static final String ANNOTATION_INPUT = "org.gradle.api.tasks.Input";
+    private static final String ANNOTATION_INPUT_FILE = "org.gradle.api.tasks.InputFile";
+    private static final String ANNOTATION_INPUT_FILES = "org.gradle.api.tasks.InputFiles";
+    private static final String ANNOTATION_INPUT_DIRECTORY = "org.gradle.api.tasks.InputDirectory";
+    private static final String ANNOTATION_OUTPUT_FILE = "org.gradle.api.tasks.OutputFile";
+    private static final String ANNOTATION_OUTPUT_FILES = "org.gradle.api.tasks.OutputFiles";
+    private static final String ANNOTATION_OUTPUT_DIRECTORY = "org.gradle.api.tasks.OutputDirectory";
+    private static final String ANNOTATION_OUTPUT_DIRECTORIES = "org.gradle.api.tasks.OutputDirectories";
+
+    private static final String RECOMMENDATION_REGULAR_FILE_PROPERTY = "RegularFileProperty";
+    private static final String RECOMMENDATION_DIRECTORY_PROPERTY = "DirectoryProperty";
+    private static final String RECOMMENDATION_LIST_PROPERTY = "ListProperty<T>";
+    private static final String RECOMMENDATION_SET_PROPERTY = "SetProperty<T>";
+    private static final String RECOMMENDATION_MAP_PROPERTY = "MapProperty<K, V>";
+
+    private static class LazyHolder {
+        private static final Set<String> MUTABLE_TYPES_THAT_SHOULD_USE_PROVIDER = new HashSet<>(Arrays.asList(
+                JAVA_LANG_STRING,
+                JAVA_LANG_INTEGER,
+                JAVA_LANG_LONG,
+                JAVA_LANG_BOOLEAN,
+                JAVA_LANG_DOUBLE,
+                JAVA_LANG_FLOAT,
+                JAVA_IO_FILE,
+                JAVA_UTIL_LIST,
+                JAVA_UTIL_SET,
+                JAVA_UTIL_MAP
+        ));
+
+        private static final Map<String, String> TYPE_TO_PROVIDER;
+        static {
+            Map<String, String> map = new HashMap<>();
+            map.put(JAVA_UTIL_LIST, RECOMMENDATION_LIST_PROPERTY);
+            map.put(JAVA_UTIL_SET, RECOMMENDATION_SET_PROPERTY);
+            map.put(JAVA_UTIL_MAP, RECOMMENDATION_MAP_PROPERTY);
+            TYPE_TO_PROVIDER = map;
+        }
+    }
+
+    private static Set<String> getMutableTypesThatShouldUseProvider() {
+        return LazyHolder.MUTABLE_TYPES_THAT_SHOULD_USE_PROVIDER;
+    }
+
+    private static Map<String, String> getTypeToProviderMap() {
+        return LazyHolder.TYPE_TO_PROVIDER;
+    }
+
+    /**
+     * Detects task input/output properties that should use Provider API types.
+     * <p>
+     * Task properties annotated with {@code @Input}, {@code @InputFile}, {@code @InputDirectory},
+     * {@code @OutputFile}, {@code @OutputDirectory}, etc. should use Provider API types
+     * ({@code Property<T>}, {@code RegularFileProperty}, {@code DirectoryProperty}, etc.)
+     * instead of plain types for lazy configuration.
+     */
+    public static final ArchRule taskInputOutputPropertiesShouldUseProviderApi = ArchRuleDefinition.priority(Priority.MEDIUM)
+            .classes()
+            .that().areAssignableTo("org.gradle.api.Task")
+            .and().areNotInterfaces()
+            .should(useProviderApiForInputOutputProperties())
+            .allowEmptyShould(true)
+            .because(
+                    "Task input/output properties should use Provider API types (Property<T>, RegularFileProperty, " +
+                    "DirectoryProperty, ConfigurableFileCollection) instead of plain types. " +
+                    "This enables lazy configuration and configuration avoidance, which significantly improves build performance. " +
+                    "See https://docs.gradle.org/current/userguide/lazy_configuration.html"
+            );
+
+    private static ArchCondition<JavaClass> useProviderApiForInputOutputProperties() {
+        return new ArchCondition<JavaClass>("use Provider API for input/output properties") {
+            @Override
+            public void check(JavaClass taskClass, ConditionEvents events) {
+                for (JavaField field : taskClass.getAllFields()) {
+                    checkFieldForProviderApiUsage(taskClass, field, events);
+                }
+
+                for (JavaMethod method : taskClass.getAllMethods()) {
+                    checkMethodForProviderApiUsage(taskClass, method, events);
+                }
+            }
+
+            private void checkFieldForProviderApiUsage(JavaClass taskClass, JavaField field, ConditionEvents events) {
+                if (!hasInputOutputAnnotation(field)) {
+                    return;
+                }
+
+                if (shouldUseProviderApi(field.getRawType()) && !usesProviderApi(field.getRawType())) {
+                    String recommendation = getSpecificRecommendation(field.getRawType(), field);
+                    String message = String.format(
+                            "Task %s has field '%s' of type %s with input/output annotation. " +
+                            "Use %s for lazy configuration.",
+                            taskClass.getSimpleName(),
+                            field.getName(),
+                            field.getRawType().getSimpleName(),
+                            recommendation
+                    );
+                    events.add(SimpleConditionEvent.violated(field, message));
+                }
+            }
+
+            private void checkMethodForProviderApiUsage(JavaClass taskClass, JavaMethod method, ConditionEvents events) {
+                if (!hasInputOutputAnnotation(method)) {
+                    return;
+                }
+
+                if (!method.getName().startsWith("get") || method.getRawParameterTypes().size() > 0) {
+                    return;
+                }
+
+                JavaClass returnType = method.getRawReturnType();
+                if (shouldUseProviderApi(returnType) && !usesProviderApi(returnType)) {
+                    String recommendation = getSpecificRecommendation(returnType, method);
+                    String message = String.format(
+                            "Task %s has getter '%s()' returning type %s with input/output annotation. " +
+                            "Use %s for lazy configuration.",
+                            taskClass.getSimpleName(),
+                            method.getName(),
+                            returnType.getSimpleName(),
+                            recommendation
+                    );
+                    events.add(SimpleConditionEvent.violated(method, message));
+                }
+            }
+
+            private boolean hasInputOutputAnnotation(JavaField field) {
+                return field.isAnnotatedWith(ANNOTATION_INPUT) ||
+                       field.isAnnotatedWith(ANNOTATION_INPUT_FILE) ||
+                       field.isAnnotatedWith(ANNOTATION_INPUT_FILES) ||
+                       field.isAnnotatedWith(ANNOTATION_INPUT_DIRECTORY) ||
+                       field.isAnnotatedWith(ANNOTATION_OUTPUT_FILE) ||
+                       field.isAnnotatedWith(ANNOTATION_OUTPUT_FILES) ||
+                       field.isAnnotatedWith(ANNOTATION_OUTPUT_DIRECTORY) ||
+                       field.isAnnotatedWith(ANNOTATION_OUTPUT_DIRECTORIES);
+            }
+
+            private boolean hasInputOutputAnnotation(JavaMethod method) {
+                return method.isAnnotatedWith(ANNOTATION_INPUT) ||
+                       method.isAnnotatedWith(ANNOTATION_INPUT_FILE) ||
+                       method.isAnnotatedWith(ANNOTATION_INPUT_FILES) ||
+                       method.isAnnotatedWith(ANNOTATION_INPUT_DIRECTORY) ||
+                       method.isAnnotatedWith(ANNOTATION_OUTPUT_FILE) ||
+                       method.isAnnotatedWith(ANNOTATION_OUTPUT_FILES) ||
+                       method.isAnnotatedWith(ANNOTATION_OUTPUT_DIRECTORY) ||
+                       method.isAnnotatedWith(ANNOTATION_OUTPUT_DIRECTORIES);
+            }
+
+            private boolean shouldUseProviderApi(JavaClass type) {
+                String typeName = type.getName();
+                return getMutableTypesThatShouldUseProvider().contains(typeName);
+            }
+
+            private boolean usesProviderApi(JavaClass type) {
+                return type.isAssignableTo("org.gradle.api.provider.Property") ||
+                       type.isAssignableTo("org.gradle.api.provider.Provider") ||
+                       type.isAssignableTo("org.gradle.api.file.RegularFileProperty") ||
+                       type.isAssignableTo("org.gradle.api.file.DirectoryProperty") ||
+                       type.isAssignableTo("org.gradle.api.file.ConfigurableFileCollection") ||
+                       type.isAssignableTo("org.gradle.api.file.FileCollection");
+            }
+
+            private String getSpecificRecommendation(JavaClass type, JavaField field) {
+                return getRecommendationForType(
+                        type,
+                        field.isAnnotatedWith(ANNOTATION_INPUT_FILE) || field.isAnnotatedWith(ANNOTATION_OUTPUT_FILE),
+                        field.isAnnotatedWith(ANNOTATION_INPUT_DIRECTORY) || field.isAnnotatedWith(ANNOTATION_OUTPUT_DIRECTORY)
+                );
+            }
+
+            private String getSpecificRecommendation(JavaClass type, JavaMethod method) {
+                return getRecommendationForType(
+                        type,
+                        method.isAnnotatedWith(ANNOTATION_INPUT_FILE) || method.isAnnotatedWith(ANNOTATION_OUTPUT_FILE),
+                        method.isAnnotatedWith(ANNOTATION_INPUT_DIRECTORY) || method.isAnnotatedWith(ANNOTATION_OUTPUT_DIRECTORY)
+                );
+            }
+
+            private String getRecommendationForType(JavaClass type, boolean isFileAnnotation, boolean isDirectoryAnnotation) {
+                String typeName = type.getName();
+
+                if (JAVA_IO_FILE.equals(typeName)) {
+                    if (isFileAnnotation) {
+                        return RECOMMENDATION_REGULAR_FILE_PROPERTY;
+                    }
+                    if (isDirectoryAnnotation) {
+                        return RECOMMENDATION_DIRECTORY_PROPERTY;
+                    }
+                    return RECOMMENDATION_REGULAR_FILE_PROPERTY + " or " + RECOMMENDATION_DIRECTORY_PROPERTY;
+                }
+
+                String mappedRecommendation = getTypeToProviderMap().get(typeName);
+                if (mappedRecommendation != null) {
+                    return mappedRecommendation;
+                }
+
+                return "Property<" + type.getSimpleName() + ">";
+            }
+        };
+    }
+
+    @Override
+    public Map<String, ArchRule> getRules() {
+        Map<String, ArchRule> rules = new HashMap<>();
+        rules.put("gradle-task-provider-api", taskInputOutputPropertiesShouldUseProviderApi);
+        return rules;
+    }
+}

--- a/archrules-gradle-plugin-development/src/archRulesTest/java/com/netflix/nebula/archrules/gradleplugins/GradlePluginLazyTaskRegistrationRuleTest.java
+++ b/archrules-gradle-plugin-development/src/archRulesTest/java/com/netflix/nebula/archrules/gradleplugins/GradlePluginLazyTaskRegistrationRuleTest.java
@@ -1,0 +1,106 @@
+package com.netflix.nebula.archrules.gradleplugins;
+
+import com.netflix.nebula.archrules.core.Runner;
+import com.tngtech.archunit.lang.EvaluationResult;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.tasks.TaskProvider;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GradlePluginLazyTaskRegistrationRuleTest {
+    private static final Logger LOG = LoggerFactory.getLogger(GradlePluginLazyTaskRegistrationRuleTest.class);
+
+    @Test
+    public void pluginUsingEagerTaskCreation_should_fail() {
+        final EvaluationResult result = Runner.check(
+                GradlePluginLazyTaskRegistrationRule.pluginsShouldUseLazyTaskRegistration,
+                PluginUsingEagerTaskCreation.class
+        );
+        LOG.info(result.getFailureReport().toString());
+        assertThat(result.hasViolation()).isTrue();
+        assertThat(result.getFailureReport().toString()).contains("uses eager task creation");
+        assertThat(result.getFailureReport().toString()).contains("Use tasks.register()");
+    }
+
+    @Test
+    public void pluginUsingTasksCreate_should_fail() {
+        final EvaluationResult result = Runner.check(
+                GradlePluginLazyTaskRegistrationRule.pluginsShouldUseLazyTaskRegistration,
+                PluginUsingTasksCreate.class
+        );
+        LOG.info(result.getFailureReport().toString());
+        assertThat(result.hasViolation()).isTrue();
+        assertThat(result.getFailureReport().toString()).contains("uses eager task creation");
+    }
+
+    @Test
+    public void pluginUsingLazyTaskRegistration_should_pass() {
+        final EvaluationResult result = Runner.check(
+                GradlePluginLazyTaskRegistrationRule.pluginsShouldUseLazyTaskRegistration,
+                PluginUsingLazyTaskRegistration.class
+        );
+        LOG.info(result.getFailureReport().toString());
+        assertThat(result.hasViolation()).isFalse();
+    }
+
+    @Test
+    public void pluginUsingTasksNamed_should_pass() {
+        final EvaluationResult result = Runner.check(
+                GradlePluginLazyTaskRegistrationRule.pluginsShouldUseLazyTaskRegistration,
+                PluginUsingTasksNamed.class
+        );
+        LOG.info(result.getFailureReport().toString());
+        assertThat(result.hasViolation()).isFalse();
+    }
+
+    @SuppressWarnings("unused")
+    public static class PluginUsingEagerTaskCreation implements Plugin<Project> {
+        @Override
+        public void apply(Project project) {
+            project.task("myTask", task -> {
+                task.setGroup("custom");
+                task.setDescription("My custom task");
+            });
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class PluginUsingTasksCreate implements Plugin<Project> {
+        @Override
+        public void apply(Project project) {
+            project.getTasks().create("myTask", Task.class, task -> {
+                task.setGroup("custom");
+                task.setDescription("My custom task");
+            });
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class PluginUsingLazyTaskRegistration implements Plugin<Project> {
+        @Override
+        public void apply(Project project) {
+            // Good practice: lazy task registration
+            project.getTasks().register("myTask", Task.class, task -> {
+                task.setGroup("custom");
+                task.setDescription("My custom task");
+            });
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class PluginUsingTasksNamed implements Plugin<Project> {
+        @Override
+        public void apply(Project project) {
+            project.getTasks().register("myTask");
+
+            project.getTasks().named("myTask", task -> {
+                task.setGroup("custom");
+            });
+        }
+    }
+}

--- a/archrules-gradle-plugin-development/src/archRulesTest/java/com/netflix/nebula/archrules/gradleplugins/GradleTaskProviderApiRuleTest.java
+++ b/archrules-gradle-plugin-development/src/archRulesTest/java/com/netflix/nebula/archrules/gradleplugins/GradleTaskProviderApiRuleTest.java
@@ -1,0 +1,183 @@
+package com.netflix.nebula.archrules.gradleplugins;
+
+import com.netflix.nebula.archrules.core.Runner;
+import com.tngtech.archunit.lang.EvaluationResult;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GradleTaskProviderApiRuleTest {
+    private static final Logger LOG = LoggerFactory.getLogger(GradleTaskProviderApiRuleTest.class);
+
+    @Test
+    public void taskWithPlainStringInput_should_fail() {
+        final EvaluationResult result = Runner.check(
+                GradleTaskProviderApiRule.taskInputOutputPropertiesShouldUseProviderApi,
+                TaskWithPlainStringInput.class
+        );
+        LOG.info(result.getFailureReport().toString());
+        assertThat(result.hasViolation()).isTrue();
+        assertThat(result.getFailureReport().toString()).contains("Use Property<String>");
+    }
+
+    @Test
+    public void taskWithPlainFileInputField_should_fail() {
+        final EvaluationResult result = Runner.check(
+                GradleTaskProviderApiRule.taskInputOutputPropertiesShouldUseProviderApi,
+                TaskWithPlainFileInputField.class
+        );
+        LOG.info(result.getFailureReport().toString());
+        assertThat(result.hasViolation()).isTrue();
+        assertThat(result.getFailureReport().toString()).contains("Use RegularFileProperty");
+    }
+
+    @Test
+    public void taskWithPlainFileOutputGetter_should_fail() {
+        final EvaluationResult result = Runner.check(
+                GradleTaskProviderApiRule.taskInputOutputPropertiesShouldUseProviderApi,
+                TaskWithPlainFileOutputGetter.class
+        );
+        LOG.info(result.getFailureReport().toString());
+        assertThat(result.hasViolation()).isTrue();
+        assertThat(result.getFailureReport().toString()).contains("Use RegularFileProperty");
+    }
+
+    @Test
+    public void taskWithPropertyApiInput_should_pass() {
+        final EvaluationResult result = Runner.check(
+                GradleTaskProviderApiRule.taskInputOutputPropertiesShouldUseProviderApi,
+                TaskWithPropertyApiInput.class
+        );
+        LOG.info(result.getFailureReport().toString());
+        assertThat(result.hasViolation()).isFalse();
+    }
+
+    @Test
+    public void taskWithRegularFileProperty_should_pass() {
+        final EvaluationResult result = Runner.check(
+                GradleTaskProviderApiRule.taskInputOutputPropertiesShouldUseProviderApi,
+                TaskWithRegularFileProperty.class
+        );
+        LOG.info(result.getFailureReport().toString());
+        assertThat(result.hasViolation()).isFalse();
+    }
+
+    @Test
+    public void taskWithDirectoryProperty_should_pass() {
+        final EvaluationResult result = Runner.check(
+                GradleTaskProviderApiRule.taskInputOutputPropertiesShouldUseProviderApi,
+                TaskWithDirectoryProperty.class
+        );
+        LOG.info(result.getFailureReport().toString());
+        assertThat(result.hasViolation()).isFalse();
+    }
+
+    @Test
+    public void taskWithoutAnnotations_should_pass() {
+        final EvaluationResult result = Runner.check(
+                GradleTaskProviderApiRule.taskInputOutputPropertiesShouldUseProviderApi,
+                TaskWithoutAnnotations.class
+        );
+        LOG.info(result.getFailureReport().toString());
+        assertThat(result.hasViolation()).isFalse();
+    }
+
+    @SuppressWarnings("unused")
+    public static abstract class TaskWithPlainStringInput extends DefaultTask {
+        @Input
+        public String message;
+
+        @TaskAction
+        public void execute() {
+            System.out.println(message);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static abstract class TaskWithPlainFileInputField extends DefaultTask {
+        @InputFile
+        public File inputFile;
+
+        @TaskAction
+        public void execute() {
+            System.out.println("Processing: " + inputFile);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static abstract class TaskWithPlainFileOutputGetter extends DefaultTask {
+        private File outputFile;
+
+        @OutputFile
+        public File getOutputFile() {
+            return outputFile;
+        }
+
+        public void setOutputFile(File file) {
+            this.outputFile = file;
+        }
+
+        @TaskAction
+        public void execute() {
+            System.out.println("Writing to: " + outputFile);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static abstract class TaskWithPropertyApiInput extends DefaultTask {
+        @Input
+        public abstract Property<String> getMessage();
+
+        @TaskAction
+        public void execute() {
+            System.out.println(getMessage().get());
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static abstract class TaskWithRegularFileProperty extends DefaultTask {
+        @InputFile
+        public abstract RegularFileProperty getInputFile();
+
+        @TaskAction
+        public void execute() {
+            System.out.println("Processing: " + getInputFile().get());
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static abstract class TaskWithDirectoryProperty extends DefaultTask {
+        @OutputDirectory
+        public abstract DirectoryProperty getOutputDir();
+
+        @TaskAction
+        public void execute() {
+            System.out.println("Writing to: " + getOutputDir().get());
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static abstract class TaskWithoutAnnotations extends DefaultTask {
+        // No input/output annotations, so plain types are fine
+        public String message;
+
+        @TaskAction
+        public void execute() {
+            System.out.println(message);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds two new ArchUnit rules to detect common Gradle plugin development anti-patterns. 

The `GradlePluginLazyTaskRegistrationRule` flags plugins using eager task creation (`project.task()` or `tasks.create()`) instead of lazy registration (`tasks.register()`)

The `GradleTaskProviderApiRule` detects task properties using plain types instead of the Provider API, providing field-specific recommendations (e.g., suggesting `RegularFileProperty` for `File` fields with `@InputFile`, or `ListProperty<T>` for `List` fields). 

