### PR TITLE
add new Gradle rule for detecting usage of DependendencySubstitutions.all()

### DIFF
--- a/archrules-gradle-plugin-development/src/archRules/java/com/netflix/nebula/archrules/gradleplugins/DependencySubstitutionsAllMethodRule.java
+++ b/archrules-gradle-plugin-development/src/archRules/java/com/netflix/nebula/archrules/gradleplugins/DependencySubstitutionsAllMethodRule.java
@@ -1,0 +1,21 @@
+package com.netflix.nebula.archrules.gradleplugins;
+
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.Priority;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+
+public class DependencySubstitutionsAllMethodRule {
+
+    public static final ArchRule DEPENDENCYSUBSTITUTIONS_ALL = ArchRuleDefinition.priority(Priority.MEDIUM)
+            .noClasses()
+            .should().callMethod(
+                    "org.gradle.api.artifacts.DependencySubstitutions",
+                    "all",
+                    "org.gradle.api.Action")
+            .allowEmptyShould(true)
+            .because(
+                    "Calling DependencySubstitutions.all causes the configuration to be resolved " +
+                    "at task graph calculation time due to the possibility of project substitutions there. " +
+                    "Instead, use DefaultDependencySubstitutions.addSubstitution or ResolutionStrategy.eachDependency."
+            );
+}

--- a/archrules-gradle-plugin-development/src/archRules/java/com/netflix/nebula/archrules/gradleplugins/GradlePluginBestPractices.java
+++ b/archrules-gradle-plugin-development/src/archRules/java/com/netflix/nebula/archrules/gradleplugins/GradlePluginBestPractices.java
@@ -7,6 +7,7 @@ import org.jspecify.annotations.NullMarked;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.netflix.nebula.archrules.gradleplugins.DependencySubstitutionsAllMethodRule.DEPENDENCYSUBSTITUTIONS_ALL;
 import static com.netflix.nebula.archrules.gradleplugins.GradleDeprecatedApiRule.pluginsShouldNotUseDeprecatedGradleApis;
 import static com.netflix.nebula.archrules.gradleplugins.GradleDeprecatedApiRule.tasksShouldNotUseDeprecatedGradleApis;
 import static com.netflix.nebula.archrules.gradleplugins.GradleInternalApiRule.PLUGIN_INTERNAL;
@@ -52,6 +53,7 @@ public class GradlePluginBestPractices implements ArchRulesService {
         rules.put("Extension abstract getters", EXTENSION_ABSTRACT_GETTERS);
         rules.put("Cacheable Task input field path sensitivity", FIELDS_PATH_SENSITIVITY);
         rules.put("Cacheable Task input method path sensitivity", METHODS_PATH_SENSITIVITY);
+        rules.put("Don't call DependendencySubstitutions.all()", DEPENDENCYSUBSTITUTIONS_ALL);
         rules.put("Apply plugins by ID", APPLY_BY_ID);
         return rules;
     }

--- a/archrules-gradle-plugin-development/src/archRulesTest/java/com/netflix/nebula/archrules/gradleplugins/DependencySubstitutionsAllMethodRuleTest.java
+++ b/archrules-gradle-plugin-development/src/archRulesTest/java/com/netflix/nebula/archrules/gradleplugins/DependencySubstitutionsAllMethodRuleTest.java
@@ -1,0 +1,27 @@
+package com.netflix.nebula.archrules.gradleplugins;
+
+import com.netflix.nebula.archrules.core.Runner;
+import com.tngtech.archunit.lang.EvaluationResult;
+import org.gradle.api.artifacts.DependencySubstitutions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DependencySubstitutionsAllMethodRuleTest {
+    @Test
+    public void pluginNotUsingDeprecatedApis_should_fail() {
+        final EvaluationResult result = Runner.check(
+                DependencySubstitutionsAllMethodRule.DEPENDENCYSUBSTITUTIONS_ALL,
+                DependencySubstitutionsAllMethodRuleTest.CodeUsingAll.class
+        );
+        assertThat(result.hasViolation()).isTrue();
+    }
+
+    static class CodeUsingAll {
+        public void bad(DependencySubstitutions substitutions) {
+            substitutions.all((substitution) -> {
+
+            });
+        }
+    }
+}


### PR DESCRIPTION
Calling DependencySubstitutions.all causes the configuration to be resolved at task graph calculation time due to the possibility of project substitutions there. Instead, use DefaultDependencySubstitutions.addSubstitution or ResolutionStrategy.eachDependency.